### PR TITLE
Add Apache 2.0 license missing from class

### DIFF
--- a/src/main/java/com/webcohesion/ofx4j/client/impl/InvestmentAccountImpl.java
+++ b/src/main/java/com/webcohesion/ofx4j/client/impl/InvestmentAccountImpl.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2008 Web Cohesion
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.webcohesion.ofx4j.client.impl;
 
 import com.webcohesion.ofx4j.OFXException;


### PR DESCRIPTION
`InvestmentAccountImpl` is missing the license header. During an audit at my employer I found the license header missing. 

The pre-webcohesion packaging at sourceforge.net did not have a `LICENSE` file at the root of the project. Starting with v1.7 the LICENSE file could be found and quickly audited. A manual audit, using `find` and `wc` vs a file-by-file inspection, showed 304 class files and 303 license headers.